### PR TITLE
Fix builds for Fedora

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,7 @@ rustflags = ["-Zshare-generics=off"]
     Config::new("manifold")
         .cxxflag(cxxflags) //  MSVC flag to enable exception handling
         .define("CMAKE_BUILD_TYPE", "Release")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .define("MANIFOLD_CROSS_SECTION", "ON")
         .define("MANIFOLD_TEST", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF")


### PR DESCRIPTION
I was having trouble building the library on Linux Fedora. As it turns out, the library was being built to a `lib64` folder instead of the expected `lib` folder!

Relevant: https://github.com/elalish/manifold/pull/946