### PR TITLE
add compile time option to use dynamic Clipper2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -70,7 +70,11 @@ rustflags = ["-Zshare-generics=off"]
     println!("cargo:rustc-link-lib=static=manifold");
 
     println!("cargo:rustc-link-search={out_dir}/build/_deps/clipper2-build");
-    println!("cargo:rustc-link-lib=static=Clipper2");
+    if env::var("CLIPPER_DYNAMIC").is_ok() {
+        println!("cargo:rustc-link-lib=Clipper2");
+    } else {
+        println!("cargo:rustc-link-lib=static=Clipper2");
+    }
 
     println!("cargo:rerun-if-changed=src/lib.rs");
     println!("cargo:rerun-if-changed=src/manifold_rs.h");


### PR DESCRIPTION
Having the clipper2 dynamic library available during compilation will make manifold's build pick up it as expected, but with the current `build.rs` the linker will try to use the non-existing static lib.